### PR TITLE
Fixed modal ref that was not being reset on logout

### DIFF
--- a/src/components/SettingsPanel/SettingsOverlay.tsx
+++ b/src/components/SettingsPanel/SettingsOverlay.tsx
@@ -147,6 +147,7 @@ export default function LoginSettingsOverlay({ children, showModal, setShowModal
           tempDivRef.current = undefined;
           setDeployModal(false);
           setShowModal(null);
+          whichModalRef.current = null;
           setCurrentModal('login'); // Reset for stalled sign up
         }, { once: true });
         overlayRef.current.classList.add('hide');


### PR DESCRIPTION
In order to keep track of whether a user should see if a login or a settings panel on icon button click, we have to set a ref to note that. The issue was the ref was keeping the value as if a user was logged in even though the user wasn't logged in. It's a simple solution. It might benefit from re-architecting. A ref was chosen because lifecycle updates were getting in the way of knowing if we had a user(uid) or not. There might be a better way to handle this. Using Redux, breaking apart the auth and db. There might be a refactor option out there ¯\_(ツ)_/¯.