### PR TITLE
Fixed stalling issue - caused by AnimatePresence mode="wait" - implemented LRU cache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "eslint-config-next": "13.4.19",
         "firebase": "^10.5.0",
         "framer-motion": "^10.16.4",
+        "lru-cache": "^10.2.0",
         "mini-css-extract-plugin": "^2.7.6",
         "next": "^13.5.6",
         "react": "18.2.0",
@@ -254,6 +255,15 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^3.0.2"
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
@@ -13598,12 +13608,11 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^3.0.2"
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
+      "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
+      "engines": {
+        "node": "14 || >=16.14"
       }
     },
     "node_modules/lz-string": {
@@ -15513,15 +15522,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
-      "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==",
-      "dev": true,
-      "engines": {
-        "node": "14 || >=16.14"
       }
     },
     "node_modules/path-to-regexp": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "eslint-config-next": "13.4.19",
     "firebase": "^10.5.0",
     "framer-motion": "^10.16.4",
+    "lru-cache": "^10.2.0",
     "mini-css-extract-plugin": "^2.7.6",
     "next": "^13.5.6",
     "react": "18.2.0",

--- a/src/components/SectionGroup/SectionGroup.tsx
+++ b/src/components/SectionGroup/SectionGroup.tsx
@@ -9,7 +9,7 @@ interface SectionGroupProps {
   startingSection: string;
   setIsNav: Dispatch<SetStateAction<boolean>>;
 }
-export default function SectionGroup({ sections, startingSection = 'us', setIsNav }: SectionGroupProps) {
+export default function SectionGroup({ sections, startingSection = 'home', setIsNav }: SectionGroupProps) {
   const [currentSection, setCurrentSection] = useState<string>(startingSection);
   const ulRef = useRef<HTMLUListElement | null>(null);
   const router = useRouter();
@@ -21,7 +21,6 @@ export default function SectionGroup({ sections, startingSection = 'us', setIsNa
 
   // We've passed in setIsNav from the parent. So, when we change section (and on initial load) we set
   // the isNavigating to true within the parent
-
   useEffect(() => {
     setIsNav(true);
     if (ulRef.current) {

--- a/src/components/ShowArticlesWithPlaceholder/ShowArticlesWithPlaceholder.tsx
+++ b/src/components/ShowArticlesWithPlaceholder/ShowArticlesWithPlaceholder.tsx
@@ -1,49 +1,77 @@
-import React from 'react';
+import React, { Dispatch } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import ArticleButtonPlaceholderGroup from '../ArticleButtonPlaceholderGroup/ArticleButtonPlaceholderGroup';
 import ArticleButtonGroup from '../ArticleButton/ArticleButtonGroup';
 import { Article } from '../types';
 import { SectionDataType } from '../../../pages/[section]';
+import createId from '@/helpers/createId';
+
+import { SetStateAction } from 'react';
 
 interface ShowArticleWithPlaceholderProps {
+  setIsNavigating: Dispatch<SetStateAction<boolean>>;
   isNavigating: boolean;
   data: SectionDataType;
 }
+
 
 /* 
 For some reason we were unable to add transitions to the framer-motion params. 
 When transition was added, the placeholder wouldn't unmount. Pretty strange, and it worth looking in to.
 It would be nice to be able to have more control over the timing.
 */
-const ShowArticleWithPlaceholder = React.memo(({ isNavigating, data }: ShowArticleWithPlaceholderProps) => {
+const ShowArticleWithPlaceholder = React.memo(({ isNavigating, setIsNavigating, data }: ShowArticleWithPlaceholderProps) => {
   // Filter out articles without a title or summary
   let articlesFiltered: Article[] = [];
   if (data) {
     articlesFiltered = data.results.filter(({ title, abstract }) => title.length > 0 && abstract.length > 0);
   }
-
   return (
-    <AnimatePresence mode='wait'>
-      {isNavigating === false ? (
-        <motion.div
-          key='articles'
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
-        >
-          <ArticleButtonGroup articles={articlesFiltered} />
-        </motion.div>
-      ) : (
-        <motion.div
-          key='placeholder'
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
-        >
-          <ArticleButtonPlaceholderGroup />
-        </motion.div>
-      )}
-    </AnimatePresence>
+    <>
+      <AnimatePresence mode="popLayout">
+        {isNavigating === false ? (
+          <motion.div
+            key={data.section}
+            initial={{ opacity: 0 }}
+            animate={{
+              opacity: 1,
+              transition: {
+                delay: 0.3,
+                duration:0.7
+              }
+            }}
+            exit={{
+              opacity: 0,
+              transition: {
+                duration: 0.3
+              }
+            }}
+          >
+            <ArticleButtonGroup articles={articlesFiltered} />
+          </motion.div>
+        ) : (
+          <motion.div
+            key="placeholders"
+            initial={{ opacity: 0 }}
+            animate={{
+              opacity: 1,
+              transition: {
+                delay: 0.3,
+                duration:0.6
+              }
+            }}
+            exit={{
+              opacity: 0,
+              transition: {
+                duration: 0.3
+              }
+            }}
+          >
+            <ArticleButtonPlaceholderGroup />
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </>
   );
 }, (prevProps, nextProps) => {
   // Only re-render if isNavigating has changed

--- a/times-pilot-email/package.json
+++ b/times-pilot-email/package.json
@@ -7,7 +7,7 @@
     "logs": "firebase functions:log"
   },
   "engines": {
-    "node": "21"
+    "node": "20"
   },
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
The issue was within [ShowArticlesWithPlaceholder.tsx](https://github.com/MisterPea/times-pilot/blob/56654f6172dd3a7eec9e9d90153cd96a6852d2cb/src/components/ShowArticlesWithPlaceholder/ShowArticlesWithPlaceholder.tsx#L26). As best as I can understand there was a conflict with `React.memo` checking `prevProps.isNavigating === nextProps.isNavigating`. I believe it's because of how `AnimatePresence mode="wait"` only animates on component at a time, when animating a component that had already existed and when `prevProps !== nextProps` it seemed to be on render behind. It's a bit fishy but works no less. 

Additionally, I added a LRU cache to allow the ssr to cache the data. This is really important considering the restrictions placed API. 