### PR TITLE
Fix for disappearing settings panel

### DIFF
--- a/src/components/SettingsPanel/settingsPanel.scss
+++ b/src/components/SettingsPanel/settingsPanel.scss
@@ -8,6 +8,8 @@
   padding: 0 2rem 0;
   margin: 0 4px;
   z-index: 0;
+  height: 100%;
+  overflow: auto;
 
   @include small--768px-and-up {
     margin: 0;


### PR DESCRIPTION
Small fix for major issue: had to explicitly set height of `.settings_panel` to `100%` along with `overflow:auto`